### PR TITLE
Update CSMetadata.json enumOptions correction

### DIFF
--- a/CustomServiceBasicCAPSample/Doc/files/CSMetadata.json
+++ b/CustomServiceBasicCAPSample/Doc/files/CSMetadata.json
@@ -253,11 +253,11 @@
               "enumOptions": [
                 {
                   "code": "ACTIVE",
-                  "summary": "Active"
+                  "description": "Active"
                 },
                 {
                   "code": "INACTIVE",
-                  "summary": "Inactive"
+                  "description": "Inactive"
                 }
               ], "searchWeightage": 1,
           "analyticsRelevant": true


### PR DESCRIPTION
When "summary" is added in the enumOptions, system cannot fetch the code descriptions. Correct term might be "description" per standard APIs. 

Changed enumOptions Code List Description - from "summary" to "decsription" to fetch code descriptions in the UI corrrectly.